### PR TITLE
Add accumulated metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Queue-it metrics don't follow [Prometheus naming conventions](https://prometheus
 | queueinflow                      | queue_it_queue_inflow_count                     |
 | queueuniqueoutflow               | queue_it_queue_unique_outflow_count             |
 | queueoutflow                     | queue_it_queue_outflow_count                    |
+| queueoutflow (Accumulated)       | queue_it_queue_outflow_accumulated              |
 | safetynetoutflow                 | queue_it_safety_net_outflow_count               |
 | queueidsinqueue                  | queue_it_queue_ids_in_queue_count               |
 | queueuniqueinflow                | queue_it_queue_unique_inflow_count              |

--- a/queue_it_test.go
+++ b/queue_it_test.go
@@ -109,14 +109,14 @@ func SkipTestGetWaitingRoomQueueStatisticsDetail(t *testing.T) {
 	}
 
 	m := &queueitMetric{
-		queueitMetricName:  "queueinflow",
-		exportedMetricName: "queue_it_queue_inflow",
+		queueitMetricName:  "queueoutflow",
+		exportedMetricName: "queue_it_queue_outflow_count",
 	}
 
-	c := make(chan *queueitMetric, 1)
+	c := make(chan *queueitMetric, 2)
 	now := time.Now()
 	then := now.Add(-1 * time.Minute)
-	q.getWaitingRoomQueueStatisticsDetail("0224allstarstdgqr3", m, then, now, c)
+	q.getWaitingRoomQueueStatisticsDetail("foo", m, true, then, now, c)
 	go func() {
 		time.Sleep(5 * time.Second)
 		close(c)

--- a/queue_it_types.go
+++ b/queue_it_types.go
@@ -106,5 +106,5 @@ type StatisticsDetail struct {
 	To               string
 	Interval         int `json:",string"`
 	Entries          []StatisticsDetailEntry
-	SumOffset        int `json:",string"`
+	SumOffset        float64 `json:",string"`
 }


### PR DESCRIPTION
Export the total accumulated value for metrics as `<exported-metric-name>_accumulated`.
Accumulated metrics export the value from the statistics details response's `SumOffset` field as opposed to the `Entries[0].Sum` for the `_count` metric, that provides the total observed events at the minute requested.